### PR TITLE
fix: upgrade fast-uri to 4.0.1, 3.1.3, 2.4.2 (CVE-2026-13676)

### DIFF
--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",
+        "fast-uri": "^3.1.3",
         "ws": "^8.18.0"
       },
       "bin": {
@@ -439,9 +440,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
       "funding": [
         {
           "type": "github",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -55,6 +55,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.28.0",
+    "fast-uri": "^3.1.3",
     "ws": "^8.18.0"
   }
 }


### PR DESCRIPTION
## Summary
Upgrade fast-uri from 3.1.0 to 4.0.1, 3.1.3, 2.4.2 to fix CVE-2026-13676.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-13676 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-13676` |
| **File** | `mcp-server/package-lock.json` |
| **Assessment** | Likely exploitable |

**Description**: fast-uri: fast-uri: Security policy bypass due to improper Unicode hostname canonicalization

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-13676` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `mcp-server/package.json`
- `mcp-server/package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
