### PR TITLE
Multi-partition support: isolated browser sessions for parallel agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Both are optional. Neither is needed for normal use.
 | `BROWSER_MCP_CHECK_NPM=1` | Makes `browser_provide_feedback` also compare this server against the latest version published on npm. Off by default, so the call stays fast and works offline. |
 | `BROWSER_MCP_EXTENSION_ID=<32-char id>` | Pins the server to one specific Chrome extension. Use it when more than one copy of Browser MCP is loaded and you want a given session to always talk to the same one. |
 
-## 40 Tools
+## 43 Tools
 
 ### Navigation & Content
 | Tool | Description |
@@ -264,6 +264,15 @@ Both are optional. Neither is needed for normal use.
 |------|-------------|
 | `browser_provide_feedback` | Self-check + report in one call. Compares this server against the latest on npm, the connected extension against this server, and detects **more than one Browser MCP extension connected at once** - the three things that explain most "it just stopped working" moments. Returns a verdict (`current` / `outdated` / `conflict` / `disconnected`), concrete fix steps, and a pre-filled issue link for whatever is genuinely missing. Your agent calls it on its own whenever a tool blocks it |
 | `browser_about` | Project info + pre-filled links to submit a wish, use-case, or bug |
+
+### Partitions (parallel agents)
+| Tool | Description |
+|------|-------------|
+| `browser_partition_new` | Open an isolated browser partition (own tab group + active tab) for one parallel agent; returns its number |
+| `browser_partition_list` | List this session's partitions (default + extras) with connection state |
+| `browser_partition_close` | Close an extra partition, releasing its port immediately |
+
+Every other tool accepts an optional `partition` number routing that call to the partition; omitting it targets the default partition.
 
 ## Multi-Session Support
 

--- a/mcp-server/index.js
+++ b/mcp-server/index.js
@@ -477,9 +477,216 @@ function sikrePort() {
   return bindLoefte;
 }
 
+// ── Partitions: isolated browser sessions for parallel agents ──────────────
+//
+// Problem: every agent sharing one MCP session (coordinator + subagents) drives
+// the SAME tab group through the default port, so concurrent agents steal and
+// close each other's tabs.
+//
+// A partition is an extra WebSocket listener in the same port range. The
+// extension scans the whole range every 2 s and connects to every listener it
+// finds, so each partition automatically becomes its own Chrome tab group with
+// its own active tab — no extension changes needed. A partition holds a scarce
+// port only while it is open; closing it (browser_partition_close, or the last
+// tab of that partition closing) releases the port immediately.
+//
+// The default-port path below is untouched: partitions neither use nor disturb
+// its lazy binding, connection pinning, or error taxonomy.
+const partitions = new Map(); // port → { server, conns: Set<{ws, version, since}> }
+
+function partitionLiveConns(port) {
+  const p = partitions.get(port);
+  if (!p) return [];
+  return [...p.conns].filter(c => c.ws.readyState === 1);
+}
+
+// Newest live connection wins on a partition port (same rule the extension
+// itself implies: one session per port, last writer owns the tab group).
+function partitionConn(port) {
+  const live = partitionLiveConns(port);
+  live.sort((a, b) => b.since - a.since);
+  return live[0] || null;
+}
+
+function closePartition(port, reason = 'partition-closed') {
+  const p = partitions.get(port);
+  if (!p) return false;
+  partitions.delete(port);
+  for (const c of p.conns) { try { c.ws.close(1000, reason); } catch {} }
+  try { p.server.close(); } catch {}
+  process.stderr.write(`[MCP] Partition ${port} closed (${reason})\n`);
+  return true;
+}
+
+function openPartition() {
+  return new Promise((resolve, reject) => {
+    const taken = new Set(partitions.keys());
+    if (activePort !== null) taken.add(activePort);
+    const tryPort = (port) => {
+      if (port > MAX_PORT) {
+        return reject(new Error(
+          `No free port in ${BASE_PORT}-${MAX_PORT} for a new partition. ` +
+          'Close an unused partition (browser_partition_close) or wait for a chat to finish.'
+        ));
+      }
+      if (taken.has(port)) return tryPort(port + 1);
+      const server = new WebSocketServer({
+        host: '127.0.0.1',
+        port,
+        // Same gate as the default listener: only real Chrome extensions.
+        verifyClient: ({ origin }, godkend) => {
+          if (/^chrome-extension:\/\/[a-p]{32}$/.test(origin || '')) return godkend(true);
+          godkend(false, 401, 'only chrome extensions may connect');
+        },
+      });
+      const entry = { server, conns: new Set() };
+      server.on('error', (err) => {
+        if (err.code === 'EADDRINUSE') tryPort(port + 1);
+        else reject(err);
+      });
+      server.on('listening', () => {
+        partitions.set(port, entry);
+        process.stderr.write(`[MCP] Partition listener on ws://127.0.0.1:${port}\n`);
+        resolve(port);
+      });
+      server.on('connection', (ws, req) => {
+        const origin = req?.headers?.origin || '';
+        const fraOrigin = /^chrome-extension:\/\/([a-p]{32})$/.exec(origin)?.[1] || null;
+        if (!fraOrigin) { try { ws.close(1008, 'only chrome extensions may connect'); } catch {} return; }
+        const conn = { ws, version: null, since: Date.now(), harHilst: false };
+        entry.conns.add(conn);
+        process.stderr.write(`[MCP] Chrome extension connected to partition ${port}\n`);
+        ws.on('message', (data) => {
+          let msg;
+          try { msg = JSON.parse(data.toString()); } catch { return; }
+          if (msg.type === 'hello') {
+            conn.harHilst = true;
+            conn.version = typeof msg.version === 'string' ? msg.version : null;
+            return;
+          }
+          if (msg.type === 'terminate') {
+            // Last tab of THIS partition closed: release just this partition.
+            // (Hello-gated like the default path; the active-connection gate is
+            // N/A here — the port exists solely for this partition.)
+            if (!conn.harHilst) return;
+            closePartition(port, 'partition-terminated');
+            return;
+          }
+          const { id, result, error } = msg;
+          const p = pending.get(id);
+          if (!p) return;
+          pending.delete(id);
+          clearTimeout(p.timer);
+          if (error) p.reject(new Error(error));
+          else p.resolve(result);
+        });
+        ws.on('error', () => { try { ws.close(); } catch {} });
+        ws.on('close', () => { entry.conns.delete(conn); });
+      });
+    };
+    tryPort(BASE_PORT);
+  });
+}
+
+async function sendToPartition(port, method, params = {}, timeoutMs = 30000, _retries = 5) {
+  const conn = partitionConn(port);
+  // The extension rescans the port range every 2 s, so a fresh partition may
+  // need a few seconds before its first command can run.
+  if (!conn) {
+    if (_retries > 0) {
+      await new Promise(r => setTimeout(r, 1500));
+      return sendToPartition(port, method, params, timeoutMs, _retries - 1);
+    }
+    if (!partitions.has(port)) {
+      throw new Error(
+        `No such browser partition: ${port}. ` +
+        'List them with browser_partition_list or open one with browser_partition_new.'
+      );
+    }
+    throw new Error(
+      `Partition ${port} has no Chrome extension connection yet. ` +
+      'The extension adopts new partitions within a few seconds — retry the command.'
+    );
+  }
+  return new Promise((resolve, reject) => {
+    const id = ++cmdId;
+    const timer = setTimeout(() => {
+      pending.delete(id);
+      reject(new Error(`Command timed out after ${timeoutMs}ms: ${method}`));
+    }, timeoutMs);
+    pending.set(id, { resolve, reject, timer });
+    harSendtKommando = true;
+    conn.ws.send(JSON.stringify({ id, method, params, pid: process.ppid }));
+  });
+}
+
+function handlePartitionNew(args) {
+  void args;
+  return openPartition().then(async (port) => {
+    // Wait for the extension to adopt the partition (2 s scan cycle).
+    let connected = false;
+    for (let i = 0; i < 8 && !connected; i++) {
+      await new Promise(r => setTimeout(r, 1000));
+      connected = !!partitionConn(port);
+    }
+    return {
+      content: [{
+        type: 'text',
+        text: JSON.stringify({
+          partition: port,
+          connected,
+          instructions: connected
+            ? `Partition ${port} is live. Pass partition: ${port} in every browser tool call made by the agent that owns it.`
+            : `Partition ${port} is open but Chrome has not connected yet. Pass partition: ${port} in every browser tool call; commands retry (~7 s) while Chrome adopts it.`,
+        }, null, 2),
+      }],
+    };
+  });
+}
+
+function handlePartitionList() {
+  const list = [...partitions.entries()].map(([port]) => ({
+    partition: port,
+    role: 'extra',
+    extension_connected: !!partitionConn(port),
+  }));
+  if (activePort !== null) {
+    list.unshift({ partition: activePort, role: 'default', extension_connected: liveConnections().length > 0 });
+  }
+  return {
+    content: [{
+      type: 'text',
+      text: JSON.stringify({ partitions: list }, null, 2),
+    }],
+  };
+}
+
+function handlePartitionClose(args) {
+  const port = args?.partition;
+  if (typeof port !== 'number') {
+    return { content: [{ type: 'text', text: 'browser_partition_close requires a numeric `partition` (see browser_partition_list).' }], isError: true };
+  }
+  if (port === activePort) {
+    return { content: [{ type: 'text', text: `Partition ${port} is this session's default partition; it cannot be closed (close its tabs instead).` }], isError: true };
+  }
+  if (!closePartition(port)) {
+    return { content: [{ type: 'text', text: `No such partition: ${port} (see browser_partition_list).` }], isError: true };
+  }
+  return {
+    content: [{
+      type: 'text',
+      text: JSON.stringify({ closed: port, note: 'Chrome releases this partition\'s tab group within ~2 s.' }, null, 2),
+    }],
+  };
+}
+
 // ── Send command to extension ───────────────────────────────────────────────
 
-async function sendToExtension(method, params = {}, timeoutMs = 30000, _retries = 5, _ekstraRunde = false, _doerAabnetNu = null) {
+async function sendToExtension(method, params = {}, timeoutMs = 30000, _retries = 5, _ekstraRunde = false, _doerAabnetNu = null, _partition = null) {
+  // A partitioned call bypasses the default port entirely (see Partitions above).
+  if (_partition !== null && _partition !== undefined) {
+    return sendToPartition(_partition, method, params, timeoutMs, _retries);
+  }
   // Skaf en port hvis vi ikke har en. Foerste kald binder; senere kald er en no-op.
   // Fik vi ingen (hele spaendet optaget), proever naeste kald igen — derfor ingen kast her.
   await sikrePort();
@@ -583,6 +790,13 @@ const INSTRUCTIONS = `You control the user's real Chrome browser via this MCP se
 - list_tabs only shows YOUR session's tabs — other Claude sessions have their own
 - switch_tab lets you jump between your tabs
 - close_tab cleans up when you're done
+
+## Partitions (parallel agents)
+A partition is an isolated browser session: its own Chrome tab group and its own active tab.
+- If multiple agents (you + subagents) drive the browser at the same time, they MUST each use their own partition or they will fight over the active tab.
+- browser_partition_new creates a fresh partition and returns its number.
+- Pass partition: <number> in EVERY browser tool call made by the agent that owns it. Omitting it targets the default partition.
+- browser_partition_list shows all partitions; browser_partition_close releases one when its agent is done.
 
 ## Authentication flows
 1. Navigate to login page
@@ -732,6 +946,16 @@ mcpServer.setRequestHandler(CallToolRequestSchema, async (request) => {
       return await handleExtractToken(args);
     }
 
+    if (name === 'browser_partition_new') {
+      return await handlePartitionNew(args);
+    }
+    if (name === 'browser_partition_list') {
+      return handlePartitionList();
+    }
+    if (name === 'browser_partition_close') {
+      return handlePartitionClose(args);
+    }
+
     const method = methodMap[name];
     if (!method) {
       return { content: [{ type: 'text', text: `Unknown tool: ${name}` }], isError: true };
@@ -739,10 +963,14 @@ mcpServer.setRequestHandler(CallToolRequestSchema, async (request) => {
 
     // extract_list scrolls a container in a loop (up to 300 rounds × wait_ms), so the 30 s
     // default would kill a long mail list mid-walk and report a partial set as complete.
-    const timeout = method === 'ask_user' ? (args?.timeout || 120000) + 5000 :
+    // Strip the routing param; the extension never sees it. Omitting it targets
+    // the default partition, exactly as before.
+    const { partition: _routingPartition, ...rest } = args || {};
+
+    const timeout = method === 'ask_user' ? (rest.timeout || 120000) + 5000 :
                     method === 'solve_captcha' ? 60000 :
                     method === 'extract_list' ? 180000 : 30000;
-    const result = await sendToExtension(method, args || {}, timeout);
+    const result = await sendToExtension(method, rest, timeout, 5, false, null, _routingPartition ?? null);
 
     if (name === 'browser_screenshot' && result?.image) {
       const isJpeg = result.image.startsWith('data:image/jpeg');
@@ -750,17 +978,17 @@ mcpServer.setRequestHandler(CallToolRequestSchema, async (request) => {
       const mimeType = isJpeg ? 'image/jpeg' : 'image/png';
       const base64 = result.image.replace(prefix, '');
 
-      if (args && args.path) {
+      if (rest && rest.path) {
         // MAALT 23/8: ingen indeslutning. En sti med ../../.. skrev til
         // /private/tmp/a360-udenfor/x.png. Argumenterne kommer fra en model der laeser
         // FREMMEDE websider, saa en prompt-injektion paa en vilkaarlig side kunne
         // overskrive en fil i brugerens hjemmemappe med PNG-bytes.
         const rod = resolve(process.cwd());
-        const targetPath = resolve(rod, args.path);
+        const targetPath = resolve(rod, rest.path);
         if (targetPath !== rod && !targetPath.startsWith(rod + sep)) {
           throw new Error(
             `path skal ligge inden for arbejdsmappen (${rod}). ` +
-            `"${args.path}" peger udenfor. Brug en relativ sti uden ../.`,
+            `"${rest.path}" peger udenfor. Brug en relativ sti uden ../.`,
           );
         }
         mkdirSync(dirname(targetPath), { recursive: true });
@@ -1159,6 +1387,7 @@ function gracefulShutdown(reason, code = 0) {
     try { c.ws.close(1000, 'mcp-shutdown'); } catch {}
   }
   if (wss) try { wss.close(); } catch {}
+  for (const port of [...partitions.keys()]) closePartition(port, 'mcp-shutdown');
 
   // 300ms grace for FIN-flush + extension session_disconnect cleanup
   setTimeout(() => process.exit(code), 300);
@@ -1170,6 +1399,11 @@ process.on('exit', () => {
   // Safety net for direct process.exit calls that bypass gracefulShutdown
   if (wss) try { wss.close(); } catch {}
   for (const c of connections) try { c.ws.close(); } catch {}
+  for (const [port, p] of [...partitions]) {
+    partitions.delete(port);
+    try { p.server.close(); } catch {}
+    for (const c of p.conns) try { c.ws.close(); } catch {}
+  }
 });
 
 // ── Naar lukker serveren sin port? (MAALT 22/8) ──────────────────────────────

--- a/mcp-server/test-partitions.py
+++ b/mcp-server/test-partitions.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""E2E test for browser-mcp partition tooling (upstream-adapted).
+
+Spawns a fresh `node index.js` from this directory, speaks MCP over stdio:
+1. tools/list exposes the 3 partition tools + partition param on tools
+2. default path still binds lazily and works untouched
+3. partition create -> extension adopts -> navigate inside -> isolation both ways
+4. unknown partition errors actionably; close semantics; default protected
+
+Needs live Chrome + extension. Leaves no tabs or partitions behind.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SERVER_DIR = str(Path(__file__).resolve().parent)
+proc = subprocess.Popen(
+    ["/usr/bin/node", "index.js"],
+    cwd=SERVER_DIR,
+    stdin=subprocess.PIPE,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+    text=True,
+    bufsize=1,
+)
+
+_next_id = [0]
+
+
+def rpc(method, params=None, notify=False):
+    msg = {"jsonrpc": "2.0", "method": method}
+    if params is not None:
+        msg["params"] = params
+    if notify:
+        proc.stdin.write(json.dumps(msg) + "\n")
+        proc.stdin.flush()
+        return None
+    _next_id[0] += 1
+    msg["id"] = _next_id[0]
+    proc.stdin.write(json.dumps(msg) + "\n")
+    proc.stdin.flush()
+    while True:
+        line = proc.stdout.readline()
+        if not line:
+            raise RuntimeError("server closed stdout")
+        resp = json.loads(line)
+        if resp.get("id") == msg["id"]:
+            return resp
+
+
+def call_tool(name, args=None):
+    resp = rpc("tools/call", {"name": name, "arguments": args or {}})
+    if resp.get("error"):
+        raise RuntimeError(f"{name}: {resp['error']}")
+    content = resp["result"]["content"]
+    text = content[0].get("text", "")
+    if resp["result"].get("isError"):
+        raise RuntimeError(f"{name} failed: {text}")
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        return text
+
+
+def check(label, cond, detail=""):
+    status = "PASS" if cond else "FAIL"
+    print(f"[{status}] {label}" + (f"  -- {detail}" if detail else ""))
+    if not cond:
+        proc.terminate()
+        sys.exit(1)
+
+
+def cleanup():
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+
+
+# 1. init
+init = rpc("initialize", {
+    "protocolVersion": "2024-11-05",
+    "capabilities": {},
+    "clientInfo": {"name": "partition-test", "version": "1.0"},
+})
+rpc("notifications/initialized", notify=True)
+check("initialize handshake", "serverInfo" in init.get("result", {}))
+
+# 2. tools list
+tools = rpc("tools/list")["result"]["tools"]
+names = [t["name"] for t in tools]
+for tname in ("browser_partition_new", "browser_partition_list", "browser_partition_close"):
+    check(f"tool exposed: {tname}", tname in names)
+for tname in ("browser_navigate", "browser_list_tabs", "browser_close_tab"):
+    tdef = next(t for t in tools if t["name"] == tname)
+    check(f"{tname} has partition param", "partition" in tdef["inputSchema"]["properties"])
+
+# 3. default path binds lazily and works (untouched behavior)
+res = call_tool("browser_navigate", {"url": "https://example.org/", "new_tab": True})
+check("default navigate works", "example.org" in json.dumps(res).lower())
+dtabs = call_tool("browser_list_tabs", {})
+d_tab = next((x for x in dtabs["tabs"] if "example.org" in x.get("url", "")), None)
+check("default sees its tab", d_tab is not None)
+D_TAB = d_tab["id"]
+
+# 4. create a partition; list shows default + new
+res = call_tool("browser_partition_new", {"label": "partition-test"})
+P = res["partition"]
+check(f"partition created (port {P})", isinstance(P, int) and 9876 <= P <= 9895)
+check("extension adopted partition", res.get("connected") is True, f"connected={res.get('connected')}")
+lst = call_tool("browser_partition_list")
+by_role = {p["role"]: p["partition"] for p in lst["partitions"]}
+check("partition list shows default + new", by_role.get("default") is not None and P in by_role.values(),
+      str(lst["partitions"])[:160])
+
+# 5. navigate INSIDE the partition; isolation both directions
+call_tool("browser_navigate", {"url": "https://example.com/", "partition": P})
+ptabs = call_tool("browser_list_tabs", {"partition": P})
+pjson = json.dumps(ptabs).lower()
+check("partition sees its tab", "example.com" in pjson, str(ptabs)[:160])
+check("partition does NOT see default tab", "example.org" not in pjson)
+dtabs = call_tool("browser_list_tabs", {})
+djson = json.dumps(dtabs).lower()
+check("default does NOT see partition tab", "example.com" not in djson, str(dtabs)[:160])
+P_TAB = next(x["id"] for x in ptabs["tabs"] if "example.com" in x.get("url", ""))
+
+# 6. unknown partition errors actionably
+resp = rpc("tools/call", {"name": "browser_navigate",
+                          "arguments": {"url": "https://example.com/", "partition": 9894}})
+errtext = resp["result"]["content"][0]["text"]
+check("unknown partition gives actionable error",
+      resp["result"].get("isError") and "browser_partition_new" in errtext, errtext[:120])
+
+# 7. close partition tab + partition; close default tab; default protected
+call_tool("browser_close_tab", {"tab_id": P_TAB, "partition": P})
+res = call_tool("browser_partition_close", {"partition": P})
+check("partition closed", res.get("closed") == P)
+res = call_tool("browser_partition_list")
+check("closed partition gone from list", P not in [p["partition"] for p in res["partitions"]])
+call_tool("browser_close_tab", {"tab_id": D_TAB})
+dtabs = call_tool("browser_list_tabs", {})
+check("default tab cleaned up", "example.org" not in json.dumps(dtabs).lower())
+dflt = next(p["partition"] for p in res["partitions"] if p["role"] == "default")
+resp = rpc("tools/call", {"name": "browser_partition_close", "arguments": {"partition": dflt}})
+check("closing default partition refused", "cannot be closed" in resp["result"]["content"][0]["text"])
+
+print("\nALL TESTS PASSED")
+cleanup()

--- a/mcp-server/tools.js
+++ b/mcp-server/tools.js
@@ -552,3 +552,56 @@ export const PROVIDER_PAGES = {
     instructions: 'Select app → Auth → Client credentials',
   },
 };
+
+// ── Partitions (parallel-agent isolation) ───────────────────────────────────
+// A partition is an isolated browser session (its own listener port → own
+// Chrome tab group + own active tab). Extra partitions are created at runtime
+// and adopted by the Chrome extension automatically. Passing `partition` in
+// any tool call routes that single call to that partition; omitting it uses
+// the default partition — exactly as before.
+
+const PARTITION_PROP = {
+  type: 'number',
+  description: 'Partition (port) to run this command in. Get one via browser_partition_new. Omit to use the default partition. Use this when multiple agents drive the browser concurrently so they never fight over the active tab.',
+};
+
+for (const t of TOOLS) {
+  // Server-local tools never touch a tab group, so routing them to a
+  // partition is meaningless: about/provide_feedback answer locally, and the
+  // partition_* tools operate on the partition registry itself.
+  if (['browser_about', 'browser_provide_feedback',
+       'browser_partition_new', 'browser_partition_list',
+       'browser_partition_close'].includes(t.name)) continue;
+  if (!t.inputSchema) t.inputSchema = { type: 'object', properties: {} };
+  if (!t.inputSchema.properties) t.inputSchema.properties = {};
+  t.inputSchema.properties.partition = PARTITION_PROP;
+}
+
+TOOLS.push(
+  {
+    name: 'browser_partition_new',
+    description: 'Create a NEW isolated browser partition (own Chrome tab group, own active tab) for a parallel agent to use without clashing with other agents. Returns the partition number. Then pass partition: <number> in EVERY browser tool call made by that agent. Chrome adopts the partition within ~2 seconds.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        label: { type: 'string', description: 'Optional human-readable label for the partition (informational only)' },
+      },
+    },
+  },
+  {
+    name: 'browser_partition_list',
+    description: 'List this session\'s browser partitions: the default port plus any extra partitions, with connection state.',
+    inputSchema: { type: 'object', properties: {} },
+  },
+  {
+    name: 'browser_partition_close',
+    description: 'Close an extra browser partition, releasing its port immediately. Chrome releases its tab group within ~2s. The default partition cannot be closed.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        partition: { type: 'number', description: 'Partition (port) to close, from browser_partition_list' },
+      },
+      required: ['partition'],
+    },
+  },
+);

--- a/test/tool-surface.test.mjs
+++ b/test/tool-surface.test.mjs
@@ -31,7 +31,7 @@ const readme = laes('README.md');
 //   browser_about             — rene links + metadata, ingen browser involveret
 //   browser_provide_feedback  — selv-diagnose af installationen, spoerger npm, ikke Chrome
 //   browser_extract_token     — sammensat: kalder selv 'navigate' og returnerer vejledning
-const SERVER_LOKALE = new Set(['browser_about', 'browser_provide_feedback', 'browser_extract_token']);
+const SERVER_LOKALE = new Set(['browser_about', 'browser_provide_feedback', 'browser_extract_token', 'browser_partition_new', 'browser_partition_list', 'browser_partition_close']);
 
 const navne = TOOLS.map(t => t.name);
 
@@ -79,7 +79,9 @@ test('hver methodMap-metode har en dispatch-case i background.js', () => {
   // Vagten skal foelge vaerktoejerne, ikke et magisk tal. MAALT 22/8: den stod paa
   // ">= 40" og blev roed da tre udklipsholder-vaerktoejer blev fjernet — en test der
   // fejler paa en KORREKT aendring er et daarligt instrument. Nu udledes den.
-  assert.ok(par.length >= TOOLS.length - 5,
+  // Server-lokale vaerktoejer (about, feedback, extract_token, partition_*) har
+  // med vilje ingen methodMap-linje: de svarer uden at roere udvidelsen.
+  assert.ok(par.length >= TOOLS.length - SERVER_LOKALE.size,
     `fandt kun ${par.length} methodMap-linjer mod ${TOOLS.length} vaerktoejer — parseren er nok braekket`);
   const cases = new Set([...bgSrc.matchAll(/case '([a-z_]+)'/g)].map(m => m[1]));
   for (const [, vaerktoej, metode] of par) {

--- a/test/vagter.test.mjs
+++ b/test/vagter.test.mjs
@@ -172,9 +172,12 @@ test('set_combobox videregiver hver parameter den annoncerer', async () => {
   const i = bg.indexOf("case 'set_combobox'");
   const blok = bg.slice(i, bg.indexOf("case '", i + 20));
 
-  // value/values haandteres saerskilt (samles til en liste), resten skal videregives.
+  // value/values haandteres saerskilt (samles til en liste), og partition
+  // forbruges server-side (strippes i index.js foer dispatch, dirigerer kaldet
+  // til en partition) — den naar aldrig udvidelsen, saa handleren skal ikke
+  // naevne den. Resten skal videregives.
   const skalVidere = Object.keys(t.inputSchema.properties)
-    .filter((k) => !['selector', 'value', 'values'].includes(k));
+    .filter((k) => !['selector', 'value', 'values', 'partition'].includes(k));
 
   for (const p of skalVidere) {
     assert.match(blok, new RegExp(p),


### PR DESCRIPTION
## Problem
When several agents share one MCP session (a coordinator plus subagents), every browser tool call targets the same server port, hence the same Chrome tab group and the same active tab. Concurrent agents steal and close each other's tabs: screenshots of the wrong page, fills landing in the wrong form, tabs closed mid-task.

## What this adds
Runtime browser partitions. A partition is an extra WebSocket listener in the same port range (`BROWSER_MCP_BASE_PORT`–`BROWSER_MCP_MAX_PORT` aware). The extension already scans the whole range every 2 s and connects to every listener it finds, so each partition automatically becomes its own Chrome tab group with its own active tab. **No extension changes needed.**

New tools:
- `browser_partition_new` — opens a partition, waits for the extension to adopt it, returns its number
- `browser_partition_list` — default port plus extras, with connection state
- `browser_partition_close` — releases an extra partition's port immediately (the default is protected)

Every other tool accepts an optional `partition` number; omitting it targets the default partition — fully backward compatible, existing clients notice nothing. Server-local tools (`browser_about`, `browser_provide_feedback`, the `partition_*` tools themselves) take no `partition` by design: they never touch a tab group.

Compatibility with lazy ports: the default-port path (lazy binding, connection pinning, error taxonomy) is untouched. A partition holds a scarce port only while it is open; closing it — or its last tab closing (`terminate`) — releases the port immediately.

## Testing
- `mcp-server/test-partitions.py`: 21-check E2E over stdio against live Chrome (tool exposure, extension adoption, cross-partition isolation in both directions, default-path coexistence, unknown-partition error path, close semantics, default-partition protection) — all pass.
- 5-agent concurrency test: five agents, five partitions, five distinct pages held open simultaneously; each partition saw only its own tab; all cleaned up afterwards.
- Existing suite: no new failures. The only failing tests (`WISHLIST paastaar...`, `bind-fejl...`) fail identically on pristine `main`. Suite guards that encode the tool inventory were updated for the 3 new tools (`SERVER_LOKALE`, methodMap tolerance now derived from it, README table + count, combobox param-forwarding exclusion for the server-routed `partition` param).